### PR TITLE
extrapolating for only colab projects

### DIFF
--- a/src/analysis/key_metrics.py
+++ b/src/analysis/key_metrics.py
@@ -1,10 +1,126 @@
 from __future__ import annotations
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Set
 from datetime import datetime, date
+from collections import defaultdict
 
+from collaborative.identify_projects import _identify_authors_from_zip
+from collaborative.identify_contributors import identify_contributors
 from config.db_config import get_connection
 from analysis.activity_classifier import aggregate as agg_by_activity
+from parsing.file_contents_manager import get_zip_file
 
+def choose_author_from_zip(uploaded_file_id: int):
+    """
+    Calls _identify_authors_from_zip(uploaded_file_id),
+    prints authors with numbered options,
+    and adds an option to select ALL authors.
+    """
+
+    authors = _identify_authors_from_zip(uploaded_file_id)
+
+    if not authors:
+        return None
+
+    authors = sorted(list(authors))  # ordered for consistency
+
+    print("\nDetected Authors:")
+    for idx, name in enumerate(authors, start=1):
+        print(f"  {idx}. {name}")
+    print(f"  {len(authors) + 1}. [Not a collaboarative project]")
+
+    # get user choice
+    while True:
+        try:
+            choice = int(input("\nSelect an option: "))
+
+            # user selected all authors
+            if choice == len(authors) + 1:
+                print("\nYou selected: ALL authors")
+                return None
+
+            # user selected a specific author
+            if 1 <= choice <= len(authors):
+                selected = authors[choice - 1]
+                return selected
+
+            print(f"Please enter a number between 1 and {len(authors) + 1}.")
+        except ValueError:
+            print("Invalid input. Enter a number.")
+
+def get_author_file_contributions_from_zip(project_id: int, author_name: str) -> Dict[str, Set[str]]:
+    """
+    For a given project_id and author_name, return all files that the author
+    created, modified, or deleted, based on the Git history inside the uploaded ZIP.
+
+    Return format:
+        {
+            "created": { "file1.py", "file2.txt", ... },
+            "modified": { "file3.py", ... },
+            "deleted": { "old_file.txt", ... }
+        }
+
+    If anything fails (no zip, no repo, author not found, etc.), returns
+    empty sets for each category.
+    """
+    # Default empty structure
+    empty_result: Dict[str, Set[str]] = {
+        "created": set(),
+        "modified": set(),
+        "deleted": set(),
+    }
+
+    if project_id <= 0:
+        return empty_result
+
+    # Get the raw ZIP bytes from your storage/DB
+    zip_data = get_zip_file(project_id)
+    if not (zip_data and isinstance(zip_data, (bytes, bytearray))):
+        # No usable zip attached to this project
+        return empty_result
+
+    ic = None
+    try:
+        ic = identify_contributors(zip_bytes=zip_data)
+        repo_path = ic.extract_repo()
+        if repo_path is None:
+            return empty_result
+
+        # Use your existing method on the class
+        file_contribs = ic.get_file_contributions()
+        if not file_contribs:
+            return empty_result
+
+        # Try exact match first
+        author_contrib = file_contribs.get(author_name)
+
+        # If not found, fall back to case-insensitive match
+        if author_contrib is None:
+            for author_key, contrib in file_contribs.items():
+                if author_key.casefold() == author_name.casefold():
+                    author_contrib = contrib
+                    break
+
+        if author_contrib is None:
+            # Author not present in Git history
+            return empty_result
+
+        # Ensure we always return sets (not whatever internal type)
+        return {
+            "created": set(author_contrib.get("created", {}).get("files", set())),
+            "modified": set(author_contrib.get("modified", {}).get("files", set())),
+            "deleted": set(author_contrib.get("deleted", {}).get("files", set())),
+        }
+
+    except Exception:
+        # If anything about the archive/repo fails, return empty
+        return empty_result
+    finally:
+        if ic is not None:
+            ic.cleanup()
+
+def get_all_files_for_author_from_zip(project_id: int, author_name: str) -> Set[str]:
+    contribs = get_author_file_contributions_from_zip(project_id, author_name)
+    return contribs["created"] | contribs["modified"] | contribs["deleted"]
 
 def fetch_records_from_db(project_id: int) -> List[Tuple[str, int, str, int]]:
     """
@@ -16,6 +132,9 @@ def fetch_records_from_db(project_id: int) -> List[Tuple[str, int, str, int]]:
     but they are not exposed in the returned tuple to keep the public
     contract simple and compatible with tests.  
     """
+    author = choose_author_from_zip(project_id)
+    user_files = get_all_files_for_author_from_zip(project_id, author)
+    
     with get_connection() as conn, conn.cursor() as cur:
         # Original query for file contents
         cur.execute(
@@ -62,7 +181,22 @@ def fetch_records_from_db(project_id: int) -> List[Tuple[str, int, str, int]]:
                     num_lines = 0
 
         results.append((str(file_path), int(size_bytes or 0), str(language or "Unknown"), int(num_lines)))
-    
+
+    if(len(user_files)>0):
+        filtered_results = []
+        for file_path, size_bytes, language, num_lines in results:
+            keep = False
+            # 1. Keep if file matches any suffix in user_files
+            for suffix in user_files:
+                if file_path.endswith(suffix):
+                    keep = True
+                    break
+            # 2. Keep if it is inside a .git folder
+            if "/.git/" in file_path:
+                keep = True
+            if keep:
+                filtered_results.append((file_path, size_bytes, language, num_lines))
+        results = filtered_results
     return results
 
 

--- a/tests/test_contributor_helpers.py
+++ b/tests/test_contributor_helpers.py
@@ -1,0 +1,195 @@
+# tests/test_contributor_helpers.py
+import builtins
+from typing import Dict, Set
+
+import pytest
+
+import analysis.key_metrics as key_metrics
+
+
+# --- Tests for choose_author_from_zip ----------------------------------------
+
+
+def test_choose_author_from_zip_no_authors(monkeypatch):
+    """If _identify_authors_from_zip returns empty, we should get None and no input is requested."""
+
+    # _identify_authors_from_zip -> empty set
+    monkeypatch.setattr(
+        "analysis.key_metrics._identify_authors_from_zip",
+        lambda uploaded_file_id: set(),
+    )
+
+    # Don't need to patch input; function should never call it
+    result = key_metrics.choose_author_from_zip(uploaded_file_id=1)
+    assert result is None
+
+
+def test_choose_author_from_zip_select_specific_author(monkeypatch):
+    """User selects a specific author (e.g., option 2)."""
+
+    # Return 2 authors; after sorting: ["Alice", "Bob"]
+    monkeypatch.setattr(
+        "analysis.key_metrics._identify_authors_from_zip",
+        lambda uploaded_file_id: {"Bob", "Alice"},
+    )
+
+    # Simulate user typing "2" (select "Bob")
+    monkeypatch.setattr("builtins.input", lambda prompt: "2")
+
+    result = key_metrics.choose_author_from_zip(uploaded_file_id=1)
+    assert result == "Bob"
+
+
+def test_choose_author_from_zip_not_collaborative(monkeypatch):
+    """User selects the 'Not a collaborative project' option."""
+
+    # Return 2 authors; menu will show 3rd option as 'Not a collaborative project'
+    monkeypatch.setattr(
+        "analysis.key_metrics._identify_authors_from_zip",
+        lambda uploaded_file_id: {"Bob", "Alice"},
+    )
+
+    # Simulate user typing "3" (len(authors) + 1)
+    monkeypatch.setattr("builtins.input", lambda prompt: "3")
+
+    result = key_metrics.choose_author_from_zip(uploaded_file_id=1)
+    # Our implementation returns None for non-collaborative
+    assert result is None
+
+
+# --- Helpers for get_author_file_contributions_from_zip tests ----------------
+
+
+class FakeIdentifyContributors:
+    """
+    Minimal fake for identify_contributors used in tests.
+    """
+
+    def __init__(self, zip_bytes: bytes):
+        self.zip_bytes = zip_bytes
+        self.cleaned = False
+
+    def extract_repo(self) -> str | None:
+        # Simulate finding a valid repo directory
+        return "/tmp/fakerepo"
+
+    def get_file_contributions(self) -> Dict[str, Dict[str, Dict]]:
+        # Simulated contributions for multiple authors
+        return {
+            "Alice": {
+                "created": {"count": 1, "files": {"src/a.py"}},
+                "modified": {"count": 1, "files": {"src/shared.py"}},
+                "deleted": {"count": 0, "files": set()},
+            },
+            "bob": {  # note lowercase key (to test case-insensitive matching)
+                "created": {"count": 1, "files": {"src/b.py"}},
+                "modified": {"count": 0, "files": set()},
+                "deleted": {"count": 1, "files": {"old/legacy.py"}},
+            },
+        }
+
+    def cleanup(self):
+        self.cleaned = True
+
+
+# --- Tests for get_author_file_contributions_from_zip ------------------------
+
+
+def test_get_author_file_contributions_bad_project_id():
+    """Project ID <= 0 should immediately return empty sets."""
+    result = key_metrics.get_author_file_contributions_from_zip(project_id=0, author_name="Alice")
+    assert result == {"created": set(), "modified": set(), "deleted": set()}
+
+
+def test_get_author_file_contributions_no_zip(monkeypatch):
+    """If get_zip_file returns no data, we should get empty sets."""
+
+    monkeypatch.setattr(
+        "analysis.key_metrics.get_zip_file",
+        lambda project_id: None,
+    )
+
+    result = key_metrics.get_author_file_contributions_from_zip(project_id=1, author_name="Alice")
+    assert result == {"created": set(), "modified": set(), "deleted": set()}
+
+
+def test_get_author_file_contributions_exact_match(monkeypatch):
+    """Exact author name match should return that author's files."""
+
+    # Simulate a valid zip blob
+    monkeypatch.setattr(
+        "analysis.key_metrics.get_zip_file",
+        lambda project_id: b"fakezipbytes",
+    )
+
+    # Patch identify_contributors constructor to return our fake
+    monkeypatch.setattr(
+        "analysis.key_metrics.identify_contributors",
+        FakeIdentifyContributors,
+    )
+
+    result = key_metrics.get_author_file_contributions_from_zip(project_id=1, author_name="Alice")
+
+    assert result["created"] == {"src/a.py"}
+    assert result["modified"] == {"src/shared.py"}
+    assert result["deleted"] == set()
+
+
+def test_get_author_file_contributions_case_insensitive(monkeypatch):
+    """Author name lookup should be case-insensitive if exact key not found."""
+
+    monkeypatch.setattr(
+        "analysis.key_metrics.get_zip_file",
+        lambda project_id: b"fakezipbytes",
+    )
+    monkeypatch.setattr(
+        "analysis.key_metrics.identify_contributors",
+        FakeIdentifyContributors,
+    )
+
+    # In FakeIdentifyContributors, we have "bob" as a key; here we ask for "Bob"
+    result = key_metrics.get_author_file_contributions_from_zip(project_id=1, author_name="Bob")
+
+    assert result["created"] == {"src/b.py"}
+    assert result["modified"] == set()
+    assert result["deleted"] == {"old/legacy.py"}
+
+
+def test_get_author_file_contributions_author_not_found(monkeypatch):
+    """Unknown author should yield empty sets."""
+
+    monkeypatch.setattr(
+        "analysis.key_metrics.get_zip_file",
+        lambda project_id: b"fakezipbytes",
+    )
+    monkeypatch.setattr(
+        "analysis.key_metrics.identify_contributors",
+        FakeIdentifyContributors,
+    )
+
+    result = key_metrics.get_author_file_contributions_from_zip(project_id=1, author_name="Charlie")
+
+    assert result == {"created": set(), "modified": set(), "deleted": set()}
+
+
+# --- Tests for get_all_files_for_author_from_zip -----------------------------
+
+
+def test_get_all_files_for_author_from_zip_union(monkeypatch):
+    """get_all_files_for_author_from_zip should return the union of created, modified, deleted."""
+
+    # Directly monkeypatch the helper to isolate this test
+    def fake_get_author_file_contributions_from_zip(project_id: int, author_name: str) -> Dict[str, Set[str]]:
+        return {
+            "created": {"src/a.py"},
+            "modified": {"src/b.py"},
+            "deleted": {"old/c.py"},
+        }
+
+    monkeypatch.setattr(
+        "analysis.key_metrics.get_author_file_contributions_from_zip",
+        fake_get_author_file_contributions_from_zip,
+    )
+
+    all_files = key_metrics.get_all_files_for_author_from_zip(project_id=1, author_name="Alice")
+    assert all_files == {"src/a.py", "src/b.py", "old/c.py"}

--- a/tests/test_key_metrics.py
+++ b/tests/test_key_metrics.py
@@ -39,6 +39,8 @@ def test_analyze_project_from_db(monkeypatch):
         ("data/users.csv", 90, "CSV", False, b"line1\nline2\nline3\nline4\nline5"),
     ]
     _mock_db(monkeypatch, rows)
+    monkeypatch.setattr("builtins.input", lambda _: "3")
+
     result = key_metrics.analyze_project_from_db(project_id=1)
     assert result["totals"]["files"] == 3
     assert result["totals"]["lines"] == 30


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description
Now for the analysis and project ranking and anything else using key_metrics if the project is collaborative it asks which user you are and then only includes the files you worked on and the .git folder. The motivation is to make our data more accurate so that only what is done by the user is shown, no dependency changes.

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

**Closes:** #124 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.
To manually see go to the main menu and select anything for analysis or ranking, then select a file you know is collaborative then select a user that contributed 1 time and then it is not collaborative a different time and yu will see that it is filtering files by what the user contributed to. To run the tests enter the command: PYTHONPATH=. pytest tests/

- [x] Manual tests
- [x] test_key_metrics.py
- [x] test_contributor_helpers.py

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
