### PR TITLE
Add full test coverage for external service permissions and collaborative decorator

### DIFF
--- a/tests/test_collaborative_decorators.py
+++ b/tests/test_collaborative_decorators.py
@@ -1,0 +1,106 @@
+"""
+Pytest tests for collaborative.decorators.requires_collaborative.
+
+Covers:
+- When collaborative permission is granted: wrapped function is executed
+- When prefs is None: wrapper prints message and does NOT call function
+- When collaborative flag is False: same行为 as no prefs
+"""
+
+import os
+import sys
+import pytest
+
+# Add src directory to Python path (same pattern as other tests)
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+src_dir = os.path.join(parent_dir, "src")
+if src_dir not in sys.path:
+    sys.path.insert(0, src_dir)
+
+from collaborative.decorators import requires_collaborative
+
+
+# Helpers
+def make_callable_tracker():
+    """
+    Returns (tracker_dict, wrapped_func) where:
+    - tracker_dict["called"] is set to True when func is executed
+    - wrapped_func() returns a known value for assertions
+    """
+    tracker = {"called": False}
+
+    @requires_collaborative
+    def sample_func(x, y=0):
+        tracker["called"] = True
+        return x + y
+
+    return tracker, sample_func
+
+def test_requires_collaborative_allows_when_flag_true(monkeypatch, capfd):
+    """
+    If CollaborativeStorage.get_preferences() returns a truthy prefs
+    with prefs[1] == True, the wrapped function should be executed.
+    """
+
+    def fake_get_prefs():
+        return (True, True, None)
+
+    monkeypatch.setattr(
+        "collaborative.decorators.CollaborativeStorage.get_preferences",
+        staticmethod(lambda: fake_get_prefs())
+    )
+
+    tracker, wrapped = make_callable_tracker()
+
+    result = wrapped(2, y=3)  # 2 + 3 = 5
+
+    out, _ = capfd.readouterr()
+    assert "Collaborative permission required" not in out
+    assert tracker["called"] is True
+    assert result == 5
+
+
+def test_requires_collaborative_blocks_when_prefs_none(monkeypatch, capfd):
+    """
+    If get_preferences() returns None, collaborative defaults to False,
+    and the wrapped function should NOT be executed.
+    """
+
+    monkeypatch.setattr(
+        "collaborative.decorators.CollaborativeStorage.get_preferences",
+        staticmethod(lambda: None)
+    )
+
+    tracker, wrapped = make_callable_tracker()
+
+    result = wrapped(1, y=2)
+
+    out, _ = capfd.readouterr()
+    assert "Collaborative permission required" in out
+    assert tracker["called"] is False
+    assert result is None  # wrapper returns None when blocked
+
+
+def test_requires_collaborative_blocks_when_flag_false(monkeypatch, capfd):
+    """
+    If get_preferences() returns a prefs tuple with collaborative=False,
+    the wrapped function should NOT be executed.
+    """
+
+    def fake_get_prefs():
+        return (True, False, None)
+
+    monkeypatch.setattr(
+        "collaborative.decorators.CollaborativeStorage.get_preferences",
+        staticmethod(lambda: fake_get_prefs())
+    )
+
+    tracker, wrapped = make_callable_tracker()
+
+    result = wrapped(10, y=20)
+
+    out, _ = capfd.readouterr()
+    assert "Collaborative permission required" in out
+    assert tracker["called"] is False
+    assert result is None

--- a/tests/test_external_service_prompt.py
+++ b/tests/test_external_service_prompt.py
@@ -1,0 +1,302 @@
+"""
+Pytest tests for ExternalServicePrompt and request_external_service_permission.
+
+Covers:
+- Storing permissions successfully and on DB error
+- Short-circuit behavior when permission already exists (True / False)
+- Full workflow when permission is not set (info + prompt + store)
+- Force re-prompting when permission exists but force=True
+
+Run with: $env:PYTHONPATH="."; pytest tests/test_external_service_prompt.py -vv
+"""
+
+import os
+import sys
+import pytest
+
+# Add src directory to Python path (same pattern as other tests)
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+src_dir = os.path.join(parent_dir, "src")
+if src_dir not in sys.path:
+    sys.path.insert(0, src_dir)
+
+from external_services import external_service_prompt as esp
+
+
+class DummyCursor:
+    """Simple fake DB cursor that records executed SQL for assertions."""
+
+    def __init__(self):
+        self.executed = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+
+class DummyCursorContext:
+    """Context manager that returns a DummyCursor."""
+
+    def __init__(self):
+        self.cursor = DummyCursor()
+
+    def __enter__(self):
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # No special handling; just allow context to exit normally
+        return False
+
+
+# Tests for ExternalServicePrompt.store_permission
+
+def test_store_permission_success(monkeypatch, capfd):
+    """store_permission should return True when DB operation succeeds."""
+
+    def fake_with_db_cursor():
+        # Simulate a working DB cursor context manager
+        return DummyCursorContext()
+
+    # Patch the with_db_cursor used inside store_permission
+    monkeypatch.setattr("config.db_config.with_db_cursor", fake_with_db_cursor)
+
+    result = esp.ExternalServicePrompt.store_permission(
+        user_id="user1", service_name="LLM", permission_granted=True
+    )
+
+    out, _ = capfd.readouterr()
+    # We don't expect an error message in the normal case
+    assert "Error storing permission" not in out
+    assert result is True
+
+
+def test_store_permission_db_error(monkeypatch, capfd):
+    """store_permission should catch DB errors and return False."""
+
+    def broken_with_db_cursor():
+        # Simulate an exception when trying to get a DB cursor
+        raise RuntimeError("DB connection failed")
+
+    monkeypatch.setattr("config.db_config.with_db_cursor", broken_with_db_cursor)
+
+    result = esp.ExternalServicePrompt.store_permission(
+        user_id="user2", service_name="LLM", permission_granted=False
+    )
+
+    out, _ = capfd.readouterr()
+    assert "Error storing permission" in out
+    assert result is False
+
+
+# Tests for request_external_service_permission
+
+class FakePermissionBase:
+    """Base fake for ExternalServicePermission; just records calls."""
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.called_with_service = []
+
+    def has_permission(self, service_name):
+        self.called_with_service.append(service_name)
+        return None
+
+
+class FakePermissionTrue(FakePermissionBase):
+    def has_permission(self, service_name):
+        self.called_with_service.append(service_name)
+        return True
+
+
+class FakePermissionFalse(FakePermissionBase):
+    def has_permission(self, service_name):
+        self.called_with_service.append(service_name)
+        return False
+
+
+class FakePermissionNone(FakePermissionBase):
+    def has_permission(self, service_name):
+        self.called_with_service.append(service_name)
+        return None
+
+
+
+class FakeServiceConfig:
+    """Fake ServiceConfig that just records initialize_table calls."""
+
+    def __init__(self):
+        self.initialized = False
+
+    def initialize_table(self):
+        self.initialized = True
+
+
+def test_request_permission_existing_true_not_forced(monkeypatch, capfd):
+    """
+    If an existing permission is True and force=False,
+    request_external_service_permission should:
+    - NOT call info / prompt / store
+    - Return True directly
+    """
+
+    # Patch ServiceConfig so it doesn't touch the real DB
+    monkeypatch.setattr(esp, "ServiceConfig", FakeServiceConfig)
+
+    # Patch ExternalServicePermission to always return True
+    monkeypatch.setattr(esp, "ExternalServicePermission", FakePermissionTrue)
+
+    flags = {"info": False, "prompt": False, "store": False}
+
+    def fake_show_info():
+        flags["info"] = True
+
+    def fake_prompt(service_name="LLM"):
+        flags["prompt"] = True
+        return True
+
+    def fake_store(user_id, service_name, permission_granted):
+        flags["store"] = True
+        return True
+
+    monkeypatch.setattr(esp.ExternalServicePrompt, "show_external_service_info", staticmethod(fake_show_info))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "prompt_for_permission", staticmethod(fake_prompt))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "store_permission", staticmethod(fake_store))
+
+    result = esp.request_external_service_permission(
+        user_id="u_existing_true", service_name="LLM", force=False
+    )
+
+    out, _ = capfd.readouterr()
+    assert "Using enhanced analysis" in out
+    assert result is True
+
+    # Ensure we short-circuited (no extra interactions)
+    assert flags["info"] is False
+    assert flags["prompt"] is False
+    assert flags["store"] is False
+
+
+def test_request_permission_existing_false_not_forced(monkeypatch, capfd):
+    """
+    If an existing permission is False and force=False,
+    request_external_service_permission should:
+    - NOT call info / prompt / store
+    - Return False directly
+    """
+
+    monkeypatch.setattr(esp, "ServiceConfig", FakeServiceConfig)
+    monkeypatch.setattr(esp, "ExternalServicePermission", FakePermissionFalse)
+
+    flags = {"info": False, "prompt": False, "store": False}
+
+    def fake_show_info():
+        flags["info"] = True
+
+    def fake_prompt(service_name="LLM"):
+        flags["prompt"] = True
+        return False
+
+    def fake_store(user_id, service_name, permission_granted):
+        flags["store"] = True
+        return True
+
+    monkeypatch.setattr(esp.ExternalServicePrompt, "show_external_service_info", staticmethod(fake_show_info))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "prompt_for_permission", staticmethod(fake_prompt))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "store_permission", staticmethod(fake_store))
+
+    result = esp.request_external_service_permission(
+        user_id="u_existing_false", service_name="LLM", force=False
+    )
+
+    out, _ = capfd.readouterr()
+    assert "Using local analysis only" in out
+    assert result is False
+
+    assert flags["info"] is False
+    assert flags["prompt"] is False
+    assert flags["store"] is False
+
+
+def test_request_permission_no_existing_runs_full_flow(monkeypatch):
+    """
+    If no existing permission (has_permission returns None),
+    the function should:
+    - call show_external_service_info
+    - call prompt_for_permission
+    - call store_permission with the chosen value
+    - return the same value as prompt_for_permission
+    """
+
+    monkeypatch.setattr(esp, "ServiceConfig", FakeServiceConfig)
+    monkeypatch.setattr(esp, "ExternalServicePermission", FakePermissionNone)
+
+    flags = {"info": False, "prompt": False, "store": False}
+    stored_calls = []
+
+    def fake_show_info():
+        flags["info"] = True
+
+    def fake_prompt(service_name="LLM"):
+        flags["prompt"] = True
+        return True  # Simulate user granting permission
+
+    def fake_store(user_id, service_name, permission_granted):
+        flags["store"] = True
+        stored_calls.append((user_id, service_name, permission_granted))
+        return True
+
+    monkeypatch.setattr(esp.ExternalServicePrompt, "show_external_service_info", staticmethod(fake_show_info))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "prompt_for_permission", staticmethod(fake_prompt))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "store_permission", staticmethod(fake_store))
+
+    result = esp.request_external_service_permission(
+        user_id="u_none", service_name="LLM", force=False
+    )
+
+    assert result is True
+    assert flags["info"] is True
+    assert flags["prompt"] is True
+    assert flags["store"] is True
+
+    # Check that store_permission was called with the expected values
+    assert stored_calls == [("u_none", "LLM", True)]
+
+
+def test_request_permission_existing_true_force_reprompts(monkeypatch):
+    """
+    When force=True, even if permission exists,
+    the function should re-run the info + prompt + store flow.
+    """
+
+    monkeypatch.setattr(esp, "ServiceConfig", FakeServiceConfig)
+    monkeypatch.setattr(esp, "ExternalServicePermission", FakePermissionTrue)
+
+    flags = {"info": False, "prompt": False, "store": False}
+    stored_calls = []
+
+    def fake_show_info():
+        flags["info"] = True
+
+    def fake_prompt(service_name="LLM"):
+        flags["prompt"] = True
+        return False  # User now declines
+
+    def fake_store(user_id, service_name, permission_granted):
+        flags["store"] = True
+        stored_calls.append((user_id, service_name, permission_granted))
+        return True
+
+    monkeypatch.setattr(esp.ExternalServicePrompt, "show_external_service_info", staticmethod(fake_show_info))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "prompt_for_permission", staticmethod(fake_prompt))
+    monkeypatch.setattr(esp.ExternalServicePrompt, "store_permission", staticmethod(fake_store))
+
+    result = esp.request_external_service_permission(
+        user_id="u_force", service_name="LLM", force=True
+    )
+
+    # Even though existing permission was True, we forced a new choice (False)
+    assert result is False
+    assert flags["info"] is True
+    assert flags["prompt"] is True
+    assert flags["store"] is True
+    assert stored_calls == [("u_force", "LLM", False)]

--- a/tests/test_permission_manager.py
+++ b/tests/test_permission_manager.py
@@ -1,0 +1,248 @@
+"""
+Pytest tests for ServiceConfig and ExternalServicePermission.
+
+Covers:
+- ServiceConfig.initialize_table success and exception branches
+- ServiceConfig.get_permission for True / False / None and error cases
+- ExternalServicePermission.initialize success/failure
+- ExternalServicePermission.has_permission behavior
+
+Run with: $env:PYTHONPATH="."; pytest tests/test_permission_manager.py -vv
+"""
+
+import os
+import sys
+import pytest
+
+# Add src directory to Python path (same pattern as other tests)
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+src_dir = os.path.join(parent_dir, "src")
+if src_dir not in sys.path:
+    sys.path.insert(0, src_dir)
+
+from external_services.service_config import ServiceConfig
+from external_services.permission_manager import ExternalServicePermission
+
+
+# Fakes for DB cursor / context
+
+class DummyCursor:
+    """Fake DB cursor that can be configured with a fetchone result."""
+
+    def __init__(self, fetchone_result=None):
+        self.fetchone_result = fetchone_result
+        self.executed = []
+
+    def execute(self, sql, params=None):
+        # Just record the calls, no real DB
+        self.executed.append((sql, params))
+
+    def fetchone(self):
+        return self.fetchone_result
+
+
+class DummyCursorContext:
+    """Context manager returning a DummyCursor."""
+
+    def __init__(self, fetchone_result=None):
+        self.cursor = DummyCursor(fetchone_result=fetchone_result)
+
+    def __enter__(self):
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+# Tests for ServiceConfig.initialize_table
+
+def test_initialize_table_success(monkeypatch, capfd):
+    """initialize_table prints success message when DB operations succeed."""
+
+    def fake_with_db_cursor():
+        # Return a context manager with a dummy cursor
+        return DummyCursorContext()
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", fake_with_db_cursor)
+
+    ServiceConfig.initialize_table()
+
+    out, _ = capfd.readouterr()
+    assert "External service permissions table initialized" in out
+
+
+def test_initialize_table_connection_error(monkeypatch):
+    """initialize_table wraps ConnectionError as a generic Exception."""
+
+    def raise_conn_error():
+        raise ConnectionError("DB down")
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", raise_conn_error)
+
+    with pytest.raises(Exception) as excinfo:
+        ServiceConfig.initialize_table()
+
+    assert "Failed to connect to database" in str(excinfo.value)
+
+
+def test_initialize_table_other_error(monkeypatch, capfd):
+    """initialize_table prints error and re-raises for generic exceptions."""
+
+    def raise_other_error():
+        raise RuntimeError("Some DB error")
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", raise_other_error)
+
+    with pytest.raises(Exception):
+        ServiceConfig.initialize_table()
+
+    out, _ = capfd.readouterr()
+    assert "Error initializing external service permissions table" in out
+
+
+# Tests for ServiceConfig.get_permission
+
+def test_get_permission_returns_true(monkeypatch):
+    """get_permission should return True when DB row has permission_granted=True."""
+
+    def fake_with_db_cursor():
+        return DummyCursorContext(fetchone_result=(True,))
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", fake_with_db_cursor)
+
+    result = ServiceConfig.get_permission("user1", "LLM")
+    assert result is True
+
+
+def test_get_permission_returns_false(monkeypatch):
+    """get_permission should return False when DB row has permission_granted=False."""
+
+    def fake_with_db_cursor():
+        return DummyCursorContext(fetchone_result=(False,))
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", fake_with_db_cursor)
+
+    result = ServiceConfig.get_permission("user2", "LLM")
+    assert result is False
+
+
+def test_get_permission_returns_none_when_no_record(monkeypatch):
+    """get_permission returns None when no record is found."""
+
+    def fake_with_db_cursor():
+        # fetchone() will return None
+        return DummyCursorContext(fetchone_result=None)
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", fake_with_db_cursor)
+
+    result = ServiceConfig.get_permission("user3", "LLM")
+    assert result is None
+
+
+def test_get_permission_connection_error(monkeypatch):
+    """get_permission returns None on ConnectionError."""
+
+    def raise_conn_error():
+        raise ConnectionError("DB down")
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", raise_conn_error)
+
+    result = ServiceConfig.get_permission("user4", "LLM")
+    assert result is None
+
+
+def test_get_permission_other_error(monkeypatch):
+    """get_permission returns None on generic exception."""
+
+    def raise_other_error():
+        raise RuntimeError("Some DB error")
+
+    monkeypatch.setattr("external_services.service_config.with_db_cursor", raise_other_error)
+
+    result = ServiceConfig.get_permission("user5", "LLM")
+    assert result is None
+
+
+# Tests for ExternalServicePermission
+
+class FakeServiceConfigOK:
+    """Fake ServiceConfig with successful initialize_table and configurable get_permission."""
+
+    def __init__(self, permission=None):
+        self.permission = permission
+        self.initialized = False
+
+    def initialize_table(self):
+        self.initialized = True
+
+    def get_permission(self, user_id, service_name):
+        return self.permission
+
+
+class FakeServiceConfigFail:
+    """Fake ServiceConfig whose initialize_table always fails."""
+
+    def initialize_table(self):
+        raise RuntimeError("init failed")
+
+    def get_permission(self, user_id, service_name):
+        return None
+
+
+def test_external_permission_initialize_success(monkeypatch):
+    """ExternalServicePermission.initialize returns True when initialize_table succeeds."""
+
+    fake_config = FakeServiceConfigOK()
+    # Patch the ServiceConfig used inside permission_manager
+    monkeypatch.setattr(
+        "external_services.permission_manager.ServiceConfig",
+        lambda: fake_config
+    )
+
+    mgr = ExternalServicePermission(user_id="u_init_ok")
+    result = mgr.initialize()
+
+    assert result is True
+    assert fake_config.initialized is True
+
+
+def test_external_permission_initialize_failure(monkeypatch, capfd):
+    """ExternalServicePermission.initialize returns False and prints error on failure."""
+
+    fake_config = FakeServiceConfigFail()
+    monkeypatch.setattr(
+        "external_services.permission_manager.ServiceConfig",
+        lambda: fake_config
+    )
+
+    mgr = ExternalServicePermission(user_id="u_init_fail")
+    result = mgr.initialize()
+
+    out, _ = capfd.readouterr()
+    assert result is False
+    assert "Failed to initialize external service permissions" in out
+
+
+@pytest.mark.parametrize(
+    "permission_value, expected",
+    [
+        (True, True),
+        (False, False),
+        (None, False),  # fallback when no record => False
+    ],
+)
+def test_external_permission_has_permission(monkeypatch, permission_value, expected):
+    """has_permission should delegate to ServiceConfig.get_permission and fallback None->False."""
+
+    fake_config = FakeServiceConfigOK(permission=permission_value)
+
+    monkeypatch.setattr(
+        "external_services.permission_manager.ServiceConfig",
+        lambda: fake_config
+    )
+
+    mgr = ExternalServicePermission(user_id="u_perm")
+    result = mgr.has_permission(service_name="LLM")
+
+    assert result is expected


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR adds new unit tests to significantly improve coverage for the external service permission system and collaborative enforcement decorator.
These tests validate the reliability of permission handling, error paths, and user-consent logic.

Included changes:
- Added test_external_service_prompt.py to cover:
1. request_external_service_permission() under all branches
2. Existing permission (allow/deny) without prompting
3. Full prompt → store workflow
4. force=True reprompt behavior
5. Table initialization and DB failure recovery

- Added test_permission_manager.py to cover:
1. ServiceConfig.initialize_table() success & exception paths
2. ServiceConfig.get_permission() for True/False/None & DB failure
3. ExternalServicePermission.initialize() and error handling
4. ExternalServicePermission.has_permission() logic

- Added test_collaborative_decorators.py to validate:
1. Allow execution when collaborative permission is granted
2. Block execution when preference is None or collaborative=False
3. Proper messaging and return behavior

These additions increase overall project test coverage to ~90%.

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing
Added three new test files under tests/
Ran full suite locally:

pytest -q

Verified code coverage using:

coverage run -m pytest
coverage report -m

Confirmed all new branches and error paths are covered.

All tests pass successfully.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes
<img width="1762" height="89" alt="image" src="https://github.com/user-attachments/assets/58dde87c-af6a-4862-8667-5676947fd2d9" />

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
