### PR TITLE
ranking persistance bug fix 

### DIFF
--- a/src/analysis/ranking_storage.py
+++ b/src/analysis/ranking_storage.py
@@ -199,8 +199,26 @@ def update_ranking_score(project_id: int, new_score: float) -> bool:
                 SET score = %s, updated_at = CURRENT_TIMESTAMP
                 WHERE project_id = %s
             """, (new_score, project_id))
-            
-            return cursor.rowcount > 0
+            if cursor.rowcount == 0:
+                return False
+
+            # Recompute rank positions based on updated scores
+            cursor.execute("""
+                UPDATE project_rankings pr
+                SET rank_position = ranked.new_pos,
+                    updated_at = CURRENT_TIMESTAMP
+                FROM (
+                    SELECT
+                        project_id,
+                        ROW_NUMBER() OVER (
+                            ORDER BY score DESC, updated_at DESC, project_id ASC
+                        ) AS new_pos
+                    FROM project_rankings
+                ) AS ranked
+                WHERE pr.project_id = ranked.project_id
+            """)
+
+            return True
     except Exception as e:
         print(f"Error updating ranking score: {e}")
         return False
@@ -310,4 +328,3 @@ def clean_error_summaries() -> bool:
     except Exception as e:
         print(f"Error cleaning error summaries: {e}")
         return False
-

--- a/src/cli/menus.py
+++ b/src/cli/menus.py
@@ -430,11 +430,10 @@ def handle_view_edit_rankings():
         print("1. View full details for a project")
         print("2. Edit score for a project")
         print("3. Edit summary for a project")
-        print("4. Change rank position for a project")
-        print("5. Clean error summaries from database")
-        print("6. Back to main menu")
+        print("4. Clean error summaries from database")
+        print("5. Back to main menu")
         
-        choice = input("\nChoose an option (1-6): ").strip()
+        choice = input("\nChoose an option (1-5): ").strip()
         
         if choice == '1':
             # View full details
@@ -512,25 +511,6 @@ def handle_view_edit_rankings():
                 print("Invalid project ID.")
         
         elif choice == '4':
-            # Change rank position
-            project_id = input("Enter project ID to change rank: ").strip()
-            if project_id.isdigit():
-                new_position = input("Enter new rank position: ").strip()
-                try:
-                    pos_int = int(new_position)
-                    if pos_int < 1:
-                        print("Rank position must be at least 1.")
-                    else:
-                        if update_ranking_position(int(project_id), pos_int):
-                            print(f"\n Successfully updated rank position for project {project_id} to {pos_int}")
-                        else:
-                            print(f"\n Failed to update rank position. Project {project_id} may not exist in stored rankings.")
-                except ValueError:
-                    print("Invalid position. Please enter a number.")
-            else:
-                print("Invalid project ID.")
-        
-        elif choice == '5':
             # Clean error summaries
             from analysis.ranking_storage import clean_error_summaries
             confirm = input("\nThis will remove all error messages from stored summaries. Continue? (y/n): ").strip().lower()
@@ -542,11 +522,11 @@ def handle_view_edit_rankings():
             else:
                 print("Cancelled.")
         
-        elif choice == '6':
+        elif choice == '5':
             break
         
         else:
-            print("Invalid choice. Please enter 1-6.")
+            print("Invalid choice. Please enter 1-5.")
 
 
 def handle_cleanup_insights():

--- a/tests/test_menus.py
+++ b/tests/test_menus.py
@@ -258,9 +258,9 @@ def test_handle_rank_and_summarize_projects(mock_input, mock_rank_and_summarize,
     mock_save.assert_called_once_with([{"id": 2}], True)
 
 
-@patch("cli.menus.update_ranking_position", return_value=True)
 @patch("cli.menus.update_ranking_summary", return_value=True)
 @patch("cli.menus.update_ranking_score", return_value=True)
+@patch("analysis.ranking_storage.clean_error_summaries", return_value=True)
 @patch(
     "cli.menus.get_stored_ranking_by_project_id",
     return_value={
@@ -286,9 +286,8 @@ def test_handle_rank_and_summarize_projects(mock_input, mock_rank_and_summarize,
         "Updated summary",
         "",  # end summary input
         "4",
-        "10",
-        "2",  # change rank
-        "6",  # back to main menu (option changed from 5 to 6)
+        "y",  # clean error summaries
+        "5",  # back to main menu
     ],
 )
 @patch("sys.stdout", new_callable=StringIO)
@@ -297,9 +296,9 @@ def test_handle_view_edit_rankings_full_loop(
     mock_input,
     mock_get_rankings,
     mock_get_by_id,
+    mock_clean,
     mock_update_score,
     mock_update_summary,
-    mock_update_position,
 ):
     """Exercise the edit rankings menu through multiple options."""
     menus.handle_view_edit_rankings()
@@ -308,12 +307,12 @@ def test_handle_view_edit_rankings_full_loop(
     assert "VIEW AND EDIT STORED RANKINGS" in out
     assert "Successfully updated score" in out
     assert "Successfully updated summary" in out
-    assert "Successfully updated rank position" in out
+    assert "Error summaries cleaned successfully" in out
 
 
 @patch("analysis.ranking_storage.clean_error_summaries", return_value=True)
 @patch("cli.menus.get_stored_rankings", return_value=[{"rank_position": 1, "project_id": 10, "score": 9.0, "ranking_data": {"filename": "example"}, "summary": "Existing"}])
-@patch("builtins.input", side_effect=["5", "y", "6"])
+@patch("builtins.input", side_effect=["4", "y", "5"])
 @patch("sys.stdout", new_callable=StringIO)
 def test_handle_view_edit_rankings_clean_error_summaries(
     mock_stdout, mock_input, mock_get_rankings, mock_clean
@@ -328,7 +327,7 @@ def test_handle_view_edit_rankings_clean_error_summaries(
 
 @patch("analysis.ranking_storage.clean_error_summaries", return_value=True)
 @patch("cli.menus.get_stored_rankings", return_value=[{"rank_position": 1, "project_id": 10, "score": 9.0, "ranking_data": {"filename": "example"}, "summary": "Existing"}])
-@patch("builtins.input", side_effect=["5", "n", "6"])
+@patch("builtins.input", side_effect=["4", "n", "5"])
 @patch("sys.stdout", new_callable=StringIO)
 def test_handle_view_edit_rankings_clean_error_summaries_cancelled(
     mock_stdout, mock_input, mock_get_rankings, mock_clean

--- a/tests/test_ranking_storage.py
+++ b/tests/test_ranking_storage.py
@@ -263,7 +263,7 @@ class TestUpdateRankingScore:
         result = update_ranking_score(10, 95.0)
         
         assert result is True
-        mock_cursor.execute.assert_called_once()
+        assert mock_cursor.execute.call_count == 2
     
     @patch('analysis.ranking_storage.with_db_cursor')
     def test_update_ranking_score_not_found(self, mock_with_db_cursor):


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

There was a bug where when ranking score was edited the ranking list was not updated to reflect the new score. There also was a way to change the rank position which is dumb because we want score to be the rank determiner.

The changes are removing the ability to change the rank of a project directly and only by score now. The main change is now when the score of a project is updated it also reorders all the rankings

There are no dependency changes.

**Closes:** #260

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

The main menu tests can be done in option 7 by changing the score enough to change the ranking and see that the ranking is consistently accurate.
The tests had to be updated a little because I got rid of the console option for changing ranking outright.

- [ ] test_menus.py and test_ranking_storage.py updated
- [ ] Manual tests

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
